### PR TITLE
Version 0.3.0

### DIFF
--- a/lib/jekyll-twitch/twitch_tag.rb
+++ b/lib/jekyll-twitch/twitch_tag.rb
@@ -8,7 +8,7 @@ module Jekyll
     end
 
     def render(context)
-      host = Jekyll::TwitchTag.site_host context
+      host = Jekyll::TwitchTag.site_url context
       %Q(<iframe
         src="#{@parsed_url}&parent=#{host}"
         height="720"
@@ -27,8 +27,8 @@ module Jekyll
       end
     end
 
-    def self.site_host(context)
-      context.registers[:site].config['host']
+    def self.site_url(context)
+      context.registers[:site].config['url']
     end
   end
 

--- a/lib/jekyll-twitch/twitch_tag.rb
+++ b/lib/jekyll-twitch/twitch_tag.rb
@@ -18,6 +18,11 @@ module Jekyll
     end
 
     # Class Methods
+    def self.hostname(url)
+      matches = url.match %r{\A(https?://)?(?<host>[A-z.]+)(:\d+)?}
+      matches[:host]
+    end
+
     def self.parse_twitch_url(url)
       url = url.strip
       case url
@@ -28,7 +33,7 @@ module Jekyll
     end
 
     def self.site_url(context)
-      context.registers[:site].config['url']
+      self.hostname(context.registers[:site].config['url'])
     end
   end
 

--- a/spec/jekyll/twitch_tag_spec.rb
+++ b/spec/jekyll/twitch_tag_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Jekyll::TwitchTag do
   describe '#render' do
     subject { Jekyll::TwitchTag }
     before do
-      allow(Jekyll::TwitchTag).to receive(:site_host).and_return("test")
+      allow(Jekyll::TwitchTag).to receive(:site_url).and_return("test")
     end
 
     it "renders a twitch embed" do

--- a/spec/jekyll/twitch_tag_spec.rb
+++ b/spec/jekyll/twitch_tag_spec.rb
@@ -5,6 +5,34 @@ RSpec.describe Jekyll::TwitchTag do
     expect(Jekyll::Twitch::VERSION).not_to be nil
   end
 
+  describe '.hostname' do
+    subject { described_class.hostname(url) }
+
+    context 'with development' do
+      let(:url) { "localhost:4000" }
+
+      it { is_expected.to eq 'localhost' }
+
+      context 'with base url' do
+        let(:url) { "https://localhost:4000/base" }
+
+        it { is_expected.to eq 'localhost' }
+      end
+    end
+
+    context 'with production' do
+      let(:url) { "https://chael.codes" }
+
+      it { is_expected.to eq 'chael.codes' }
+    end
+
+    context 'with base url' do
+      let(:url) { "https://chael.codes/base" }
+
+      it { is_expected.to eq 'chael.codes' }
+    end
+  end
+
   describe '.parse_twitch_url' do
     subject { Jekyll::TwitchTag.parse_twitch_url(url) }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,5 @@
 require "bundler/setup"
-require "twitch_tag"
+require "jekyll-twitch"
 require "jekyll"
 
 RSpec.configure do |config|


### PR DESCRIPTION
## Replace site host with site url
Twitch requires that the page url for the embed be passed. The  previous
version site host was always 127.0.0.1. Url should be localhost in dev
and the site url in production.