### PR TITLE
Version 1

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,6 +9,14 @@ AllCops:
 require:
   - rubocop-rspec
 
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*'
+
+Naming/FileName:
+  Exclude:
+    - 'lib/jekyll-twitch.rb'
+
 RSpec/ImplicitSubject:
   Enabled: false
 

--- a/docs/_posts/2021-04-23-Version-1-Released.md
+++ b/docs/_posts/2021-04-23-Version-1-Released.md
@@ -1,0 +1,9 @@
+---
+layout: post
+date: 2021-04-23
+---
+Version 1.0 of Jekyll-Twitch has just been released!
+
+- embed now sizes to the parent div instead of being a fixed 1280x720
+  - See the example pages on the documentation site for more details
+- Supports clips, channels, collections, and vods

--- a/docs/channel.md
+++ b/docs/channel.md
@@ -1,0 +1,17 @@
+---
+layout: page
+title: Channel
+permalink: /channel/
+---
+This embeds a live broadcast of a particular channel in your page or post.
+
+{% raw %}
+```
+<div style="width:720px;height:480px">
+  {% twitch https://twitch.tv/ChaelCodes %}
+</div>
+```
+{% endraw %}
+<div style="width:720px;height:480px">
+  {% twitch https://twitch.tv/ChaelCodes %}
+</div>

--- a/docs/collection.md
+++ b/docs/collection.md
@@ -1,0 +1,17 @@
+---
+layout: page
+title: Collection
+permalink: /collection/
+---
+This embed is used to add a collection of videos to your page or post.
+
+{% raw %}
+```
+<div style="width:720px;height:480px">
+  {% twitch https://www.twitch.tv/collections/x5bG2TGTeBYIRg %}
+</div>
+```
+{% endraw %}
+<div style="width:720px;height:480px">
+  {% twitch https://www.twitch.tv/collections/x5bG2TGTeBYIRg %}
+</div>

--- a/docs/videos.md
+++ b/docs/videos.md
@@ -1,0 +1,17 @@
+---
+layout: page
+title: Videos
+permalink: /videos/
+---
+Whether you call them videos, vods, or higlights, this will embed them in your page or psot.
+
+{% raw %}
+```
+<div style="width:720px;height:480px">
+  {% twitch https://www.twitch.tv/videos/716698136 %}
+</div>
+```
+{% endraw %}
+<div style="width:720px;height:480px">
+  {% twitch https://www.twitch.tv/videos/716698136 %}
+</div>

--- a/lib/jekyll-twitch.rb
+++ b/lib/jekyll-twitch.rb
@@ -1,9 +1,8 @@
-# rubocop:disable Naming/FileName
 # frozen_string_literal: true
 
 require 'jekyll-twitch/version'
 require 'jekyll-twitch/twitch_tag'
-# rubocop:enable Naming/FileName
+
 module Jekyll
   # This is the module for Twitch stuff for Jekyll
   module Twitch

--- a/lib/jekyll-twitch/twitch_tag.rb
+++ b/lib/jekyll-twitch/twitch_tag.rb
@@ -16,8 +16,8 @@ module Jekyll
       host = Jekyll::TwitchTag.site_url context
       %(<iframe
         src="#{@parsed_url}&parent=#{host}"
-        height="720"
-        width="1280"
+        height="100%"
+        width="100%"
         allowfullscreen="true">
       </iframe>)
     end

--- a/lib/jekyll-twitch/twitch_tag.rb
+++ b/lib/jekyll-twitch/twitch_tag.rb
@@ -34,6 +34,9 @@ module Jekyll
       when %r{/clip/}
         slug = url.match %r{(?<no>/clip/)(?<clip>.+)}
         "https://clips.twitch.tv/embed?autoplay=false&clip=#{slug[:clip]}"
+      else
+        slug = url.match %r{(?<no>twitch.tv/)(?<channel>.+)/?}
+        "https://player.twitch.tv/?channel=#{slug[:channel]}&autoplay=false"
       end
     end
 

--- a/lib/jekyll-twitch/twitch_tag.rb
+++ b/lib/jekyll-twitch/twitch_tag.rb
@@ -33,6 +33,11 @@ module Jekyll
       "https://clips.twitch.tv/embed?autoplay=false&clip=#{slug[:clip]}"
     end
 
+    def self.collection_url(url)
+      slug = url.match %r{(?<no>/collections/)(?<collection>.+)/?\??}
+      "https://player.twitch.tv/?collection=#{slug[:collection]}&autoplay=false"
+    end
+
     def self.hostname(url)
       matches = url.match %r{\A(?<safe>https?://)?(?<host>[A-z.]+)(?<port>:\d+)?}
       matches[:host]
@@ -45,6 +50,8 @@ module Jekyll
         clip_url url
       when %r{/videos/}
         video_url url
+      when %r{/collections/}
+        collection_url url
       else
         channel_url url
       end

--- a/lib/jekyll-twitch/twitch_tag.rb
+++ b/lib/jekyll-twitch/twitch_tag.rb
@@ -23,6 +23,16 @@ module Jekyll
     end
 
     # Class Methods
+    def self.channel_url(url)
+      slug = url.match %r{(?<no>twitch.tv/)(?<channel>.+)/?\??}
+      "https://player.twitch.tv/?channel=#{slug[:channel]}&autoplay=false"
+    end
+
+    def self.clip_url(url)
+      slug = url.match %r{(?<no>/clip/)(?<clip>.+)/?\??}
+      "https://clips.twitch.tv/embed?autoplay=false&clip=#{slug[:clip]}"
+    end
+
     def self.hostname(url)
       matches = url.match %r{\A(?<safe>https?://)?(?<host>[A-z.]+)(?<port>:\d+)?}
       matches[:host]
@@ -32,16 +42,21 @@ module Jekyll
       url = url.strip
       case url
       when %r{/clip/}
-        slug = url.match %r{(?<no>/clip/)(?<clip>.+)}
-        "https://clips.twitch.tv/embed?autoplay=false&clip=#{slug[:clip]}"
+        clip_url url
+      when %r{/videos/}
+        video_url url
       else
-        slug = url.match %r{(?<no>twitch.tv/)(?<channel>.+)/?}
-        "https://player.twitch.tv/?channel=#{slug[:channel]}&autoplay=false"
+        channel_url url
       end
     end
 
     def self.site_url(context)
       hostname(context.registers[:site].config['url'])
+    end
+
+    def self.video_url(url)
+      slug = url.match %r{(?<no>/videos/)(?<vod>\d+)}
+      "https://player.twitch.tv/?video=#{slug[:vod]}&autoplay=false"
     end
   end
 

--- a/lib/jekyll-twitch/twitch_tag.rb
+++ b/lib/jekyll-twitch/twitch_tag.rb
@@ -9,7 +9,7 @@ module Jekyll
   class TwitchTag < Liquid::Tag
     def initialize(_tag_name, content, _tokens)
       super
-      @parsed_url = Jekyll::TwitchTag.parse_twitch_url content
+      @parsed_url = Jekyll::TwitchTag.parse_twitch_url content.strip
     end
 
     def render(context)
@@ -44,7 +44,6 @@ module Jekyll
     end
 
     def self.parse_twitch_url(url)
-      url = url.strip
       case url
       when %r{/clip/}
         clip_url url

--- a/lib/jekyll-twitch/version.rb
+++ b/lib/jekyll-twitch/version.rb
@@ -2,6 +2,6 @@
 
 module Jekyll
   module Twitch
-    VERSION = '0.2.0'
+    VERSION = '1.0.0'
   end
 end

--- a/spec/jekyll/twitch_tag_spec.rb
+++ b/spec/jekyll/twitch_tag_spec.rb
@@ -53,6 +53,22 @@ RSpec.describe Jekyll::TwitchTag do
         is_expected.to eq 'https://player.twitch.tv/?channel=ChaelCodes&autoplay=false'
       }
     end
+
+    context 'with vod url' do
+      let(:url) { 'https://www.twitch.tv/videos/716698136' }
+
+      it {
+        is_expected.to eq 'https://player.twitch.tv/?video=716698136&autoplay=false'
+      }
+
+      context 'with messy url' do
+        let(:url) { 'https://www.twitch.tv/videos/716698136?filter=highlights&sort=views' }
+
+        it {
+          is_expected.to eq 'https://player.twitch.tv/?video=716698136&autoplay=false'
+        }
+      end
+    end
   end
 
   describe '#render' do
@@ -87,6 +103,25 @@ RSpec.describe Jekyll::TwitchTag do
       # rubocop:disable Layout/IndentationWidth
       %(<iframe
         src="https://player.twitch.tv/?channel=ChaelCodes&autoplay=false&parent=test"
+        height="100%"
+        width="100%"
+        allowfullscreen="true">
+      </iframe>)
+        # rubocop:enable Layout/IndentationWidth
+      end
+
+      it 'renders a twitch embed' do
+        liquid = tag.render
+        expect(liquid).to eq result
+      end
+    end
+
+    context 'with VoD' do
+      let(:tag) { Liquid::Template.parse('{% twitch https://www.twitch.tv/videos/716698136 %}') }
+      let(:result) do
+      # rubocop:disable Layout/IndentationWidth
+      %(<iframe
+        src="https://player.twitch.tv/?video=716698136&autoplay=false&parent=test"
         height="100%"
         width="100%"
         allowfullscreen="true">

--- a/spec/jekyll/twitch_tag_spec.rb
+++ b/spec/jekyll/twitch_tag_spec.rb
@@ -2,7 +2,7 @@
 
 require 'pry'
 
-RSpec.describe Jekyll::TwitchTag do # rubocop:disable Metrics/BlockLength
+RSpec.describe Jekyll::TwitchTag do
   it 'has a version number' do
     expect(Jekyll::Twitch::VERSION).not_to be nil
   end

--- a/spec/jekyll/twitch_tag_spec.rb
+++ b/spec/jekyll/twitch_tag_spec.rb
@@ -45,6 +45,14 @@ RSpec.describe Jekyll::TwitchTag do
         is_expected.to eq 'https://clips.twitch.tv/embed?autoplay=false&clip=LongClipName-uuid1234'
       }
     end
+
+    context 'with channel url' do
+      let(:url) { 'https://twitch.tv/ChaelCodes' }
+
+      it {
+        is_expected.to eq 'https://player.twitch.tv/?channel=ChaelCodes&autoplay=false'
+      }
+    end
   end
 
   describe '#render' do
@@ -54,18 +62,42 @@ RSpec.describe Jekyll::TwitchTag do
       allow(described_class).to receive(:site_url).and_return('test')
     end
 
-    let(:tag) { Liquid::Template.parse('{% twitch https://www.twitch.tv/chaelcodes/clip/LongClipName-uuid1234 %}') }
-
-    it 'renders a twitch embed' do # rubocop:disable RSpec/ExampleLength
-      liquid = tag.render
-      expect(liquid).to eq(
-        %(<iframe
+    context 'with clip' do
+      let(:tag) { Liquid::Template.parse('{% twitch https://www.twitch.tv/chaelcodes/clip/LongClipName-uuid1234 %}') }
+      let(:result) do
+      # rubocop:disable Layout/IndentationWidth
+      %(<iframe
         src="https://clips.twitch.tv/embed?autoplay=false&clip=LongClipName-uuid1234&parent=test"
         height="100%"
         width="100%"
         allowfullscreen="true">
       </iframe>)
-      ) # https://player.twitch.tv/?
+        # rubocop:enable Layout/IndentationWidth
+      end
+
+      it 'renders a twitch embed' do
+        liquid = tag.render
+        expect(liquid).to eq result
+      end
+    end
+
+    context 'with channel' do
+      let(:tag) { Liquid::Template.parse('{% twitch https://twitch.tv/ChaelCodes %}') }
+      let(:result) do
+      # rubocop:disable Layout/IndentationWidth
+      %(<iframe
+        src="https://player.twitch.tv/?channel=ChaelCodes&autoplay=false&parent=test"
+        height="100%"
+        width="100%"
+        allowfullscreen="true">
+      </iframe>)
+        # rubocop:enable Layout/IndentationWidth
+      end
+
+      it 'renders a twitch embed' do
+        liquid = tag.render
+        expect(liquid).to eq result
+      end
     end
   end
 

--- a/spec/jekyll/twitch_tag_spec.rb
+++ b/spec/jekyll/twitch_tag_spec.rb
@@ -61,8 +61,8 @@ RSpec.describe Jekyll::TwitchTag do # rubocop:disable Metrics/BlockLength
       expect(liquid).to eq(
         %(<iframe
         src="https://clips.twitch.tv/embed?autoplay=false&clip=LongClipName-uuid1234&parent=test"
-        height="720"
-        width="1280"
+        height="100%"
+        width="100%"
         allowfullscreen="true">
       </iframe>)
       ) # https://player.twitch.tv/?

--- a/spec/jekyll/twitch_tag_spec.rb
+++ b/spec/jekyll/twitch_tag_spec.rb
@@ -54,6 +54,14 @@ RSpec.describe Jekyll::TwitchTag do
       }
     end
 
+    context 'with collection url' do
+      let(:url) { 'https://www.twitch.tv/collections/x5bG2TGTeBYIRg' }
+
+      it {
+        is_expected.to eq 'https://player.twitch.tv/?collection=x5bG2TGTeBYIRg&autoplay=false'
+      }
+    end
+
     context 'with vod url' do
       let(:url) { 'https://www.twitch.tv/videos/716698136' }
 
@@ -103,6 +111,25 @@ RSpec.describe Jekyll::TwitchTag do
       # rubocop:disable Layout/IndentationWidth
       %(<iframe
         src="https://player.twitch.tv/?channel=ChaelCodes&autoplay=false&parent=test"
+        height="100%"
+        width="100%"
+        allowfullscreen="true">
+      </iframe>)
+        # rubocop:enable Layout/IndentationWidth
+      end
+
+      it 'renders a twitch embed' do
+        liquid = tag.render
+        expect(liquid).to eq result
+      end
+    end
+
+    context 'with collection' do
+      let(:tag) { Liquid::Template.parse('{% twitch https://www.twitch.tv/collections/x5bG2TGTeBYIRg %}') }
+      let(:result) do
+      # rubocop:disable Layout/IndentationWidth
+      %(<iframe
+        src="https://player.twitch.tv/?collection=x5bG2TGTeBYIRg&autoplay=false&parent=test"
         height="100%"
         width="100%"
         allowfullscreen="true">


### PR DESCRIPTION

# Description 
- Let external div determine size of embed instead of using a fixed 1280x720.
- Now supports embedding Vods, Collections, and Channels

# Extras
- Add Blocklength and Filename rules back to Rubocop.
